### PR TITLE
Correggi il percorso del Dockerfile nello script di deploy e aggiungi…

### DIFF
--- a/deply.sh
+++ b/deply.sh
@@ -4,7 +4,7 @@
 git pull --rebase origin main
 
 # Rebuild the Docker image
-docker build --file eddai_EliteDangerousApiInterface\Dockerfile -t eddaielitedangerousapiinterface:latest "eddai_EliteDangerousApiInterface"
+docker build --file eddai_EliteDangerousApiInterface/Dockerfile -t eddaielitedangerousapiinterface:latest "eddai_EliteDangerousApiInterface"
 
 # Apply the latest migrations
 docker run --env-file .env --rm eddaielitedangerousapiinterface:latest python manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         ports:
             - "6379:6379"
         restart: always
+        command: redis-server --requirepass ${REDIS_RESULT_BACKEND_PASSWORD}
         volumes:
             - redisresultbackendvol:/data
     redis_cache:
@@ -32,6 +33,7 @@ services:
         ports:
             - "6380:6379"
         restart: always
+        command: redis-server --requirepass ${REDIS_CACHE_PASSWORD}
         volumes:
             - rediscachevol:/data
     postgis:


### PR DESCRIPTION
This pull request includes changes to the deployment script and the `docker-compose.yml` file to fix a path error and add password protection for Redis services.

Deployment script update:

* [`deploy.sh`](diffhunk://#diff-d4b5b016f0a04fb81b72b162cdd39b621ef2d801115c303cd2a78342467f6f1bL7-R7): Fixed the Dockerfile path by replacing the backslash with a forward slash.

Docker Compose updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R25): Added a command to require a password for the `redis_result_backend` service using the `${REDIS_RESULT_BACKEND_PASSWORD}` environment variable.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R36): Added a command to require a password for the `redis_cache` service using the `${REDIS_CACHE_PASSWORD}` environment variable.