### PR TITLE
Remove obsolete version from docker-compose files

### DIFF
--- a/docker-compose-services.yml
+++ b/docker-compose-services.yml
@@ -1,4 +1,3 @@
-version: "2.0"
 services:
     rabbitmq:
         container_name: rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.0"
 x-common-config: &default-config
   build: ./eddai_EliteDangerousApiInterface
   environment:


### PR DESCRIPTION
Eliminate the outdated version specification from `docker-compose.yml` and `docker-compose-services.yml`.