### PR TITLE
Rimuovi le estensioni GitHub Copilot dal file devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,6 @@
 				"ms-python.vscode-pylance",
 				"snappify.snappify",
 				"esbenp.prettier-vscode",
-				"GitHub.copilot",
-				"GitHub.copilot-chat",
 				"mhutchie.git-graph",
 				"dzhavat.bracket-pair-toggler"
 			]


### PR DESCRIPTION
This pull request includes a change to the `.devcontainer/devcontainer.json` file. The change removes the `GitHub.copilot` and `GitHub.copilot-chat` extensions from the list of installed extensions.

Changes to `.devcontainer/devcontainer.json`:

* Removed `GitHub.copilot` extension.
* Removed `GitHub.copilot-chat` extension.