### PR TITLE
Update maximum relations, add optional economies support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -133,6 +133,9 @@
         "--noinput"
       ],
       "django": true,
+      "env": {
+        "DJANGO_SETTINGS_MODULE": "eddai_EliteDangerousApiInterface.settings.test"
+      },
       "consoleTitle": "Python Debug Django Tests"
     }
   ],

--- a/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
+++ b/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
@@ -34,7 +34,7 @@ class PowerInSystem(OwnerAndDateModels):
         """
         Returns the maximum relation value.
         """
-        return 2
+        return 4
 
     @staticmethod
     def StateForMoreRellation() -> PowerState:

--- a/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Commodity.json
+++ b/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Commodity.json
@@ -3501,5 +3501,47 @@
             },
             "error": null
         }
+    },
+    {
+        "model": "eddn.datalog",
+        "pk": 164530,
+        "fields": {
+            "created_at": "2025-02-14T23:47:59.086Z",
+            "updated_at": "2025-02-14T23:47:59.086Z",
+            "data": {
+                "header": {
+                    "gamebuild": "r308767/r0 ",
+                    "uploaderID": "923094d38a562ba31375fa8ec7d82300d8e47357",
+                    "gameversion": "4.0.0.1904",
+                    "softwareName": "E:D Market Connector [Windows]",
+                    "softwareVersion": "5.12.2",
+                    "gatewayTimestamp": "2025-02-19T10:22:41.588583Z"
+                },
+                "message": {
+                    "odyssey": true,
+                    "horizons": true,
+                    "marketId": 3707008000,
+                    "timestamp": "2025-02-19T10:22:40Z",
+                    "systemName": "Harma",
+                    "commodities": [
+                        {
+                            "name": "bromellite",
+                            "stock": 0,
+                            "demand": 3601,
+                            "buyPrice": 0,
+                            "meanPrice": 0,
+                            "sellPrice": 500107,
+                            "stockBracket": 0,
+                            "demandBracket": 2
+                        }
+                    ],
+                    "stationName": "G3J-12N",
+                    "stationType": "FleetCarrier",
+                    "carrierDockingAccess": "all"
+                },
+                "$schemaRef": "https://eddn.edcd.io/schemas/commodity/3"
+            },
+            "error": null
+        }
     }
 ]

--- a/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Location.json
+++ b/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Location.json
@@ -160,7 +160,9 @@
                     "BodyID": 17,
                     "Docked": true,
                     "Powers": [
-                        "Yuri Grom",
+                        "A. Lavigny-Duval",
+                        "Aisling Duval",
+                        "Felicia Winters",
                         "Zemina Torval"
                     ],
                     "StarPos": [

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/commodity/commodityV3Serializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/commodity/commodityV3Serializer.py
@@ -17,7 +17,7 @@ class CommodityV3Serializer(BaseSerializer):
         min_length=1
     )
     economies = EconomyLowerSerializer(
-        many=True
+        many=True, required=False
     )
     commodities = CommoditySerializer(
         many=True
@@ -35,13 +35,17 @@ class CommodityV3Serializer(BaseSerializer):
 
     def _get_primary_economy(self, data) -> Economy:
         """Get the primary economy from the sorted list of station economies."""
-        StationEconomies:list[dict] = data.get('economies')
+        StationEconomies:list[dict] = data.get('economies', [])
+        if not StationEconomies:
+            return None
         self._sort_economies(StationEconomies)
         return StationEconomies[0].get('name')
     
     def _get_secondary_economy(self, data) -> Economy:
         """Get the secondary economy from the sorted list of station economies."""
-        StationEconomies:list[dict] = data.get('economies')
+        StationEconomies:list[dict] = data.get('economies', [])
+        if not StationEconomies:
+            return None
         if len(StationEconomies) == 1:
             return Economy.objects.get(eddn='$economy_None;')
         self._sort_economies(StationEconomies)


### PR DESCRIPTION
Increase the maximum relation value to 4, implement support for optional economies in the CommodityV3Serializer.