### PR TITLE
Reduce concurrency limit and improve Celery task management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,15 +38,15 @@ services:
   celery_worker_task:
     <<: *default-config
     container_name: celery_worker_task
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q default -n WorkerTasck@%h 
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q default -n WorkerTasck@%h --without-gossip 
   celery_worker_admin:
     <<: *default-config
     container_name: celery_worker_admin
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q admin -n WorkerAdmin@%h
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q admin -n WorkerAdmin@%h --without-gossip
   celery_worker_eddn:
     <<: *default-config
     container_name: celery_worker_eddn
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q eddn -n WorkerEddn@%h
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q eddn -n WorkerEddn@%h --without-gossip
   celery_beat:
     <<: *default-config
     container_name: celery_beat

--- a/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
+++ b/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
@@ -256,7 +256,6 @@ LOGGING = {
     "handlers": {
         "celery.task.console": {
             "level": "INFO",
-            "filters": ["require_debug_true"],
             "class": "logging.StreamHandler",
             "formatter": "celery.task.console",
         },
@@ -339,7 +338,7 @@ CELERY_RESULT_BACKEND =  F'redis://{os.environ.get("CELERY_RESULT_BACKEND_HOST")
 
 #impostazioni per la gestione del heartbeat del broker
 #https://docs.celeryq.dev/en/v5.4.0/userguide/configuration.html#broker-heartbeat
-CELERY_BROKER_HEARTBEAT = 120.0
+CELERY_BROKER_HEARTBEAT = 0
 
 #impostazioni per la gestione della serializzazione dei dati
 #https://docs.celeryq.dev/en/stable/userguide/calling.html#serializers

--- a/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
+++ b/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
@@ -339,7 +339,7 @@ CELERY_RESULT_BACKEND =  F'redis://{os.environ.get("CELERY_RESULT_BACKEND_HOST")
 
 #impostazioni per la gestione del heartbeat del broker
 #https://docs.celeryq.dev/en/v5.4.0/userguide/configuration.html#broker-heartbeat
-CELERY_BROKER_HEARTBEAT = 0
+CELERY_BROKER_HEARTBEAT = 120.0
 
 #impostazioni per la gestione della serializzazione dei dati
 #https://docs.celeryq.dev/en/stable/userguide/calling.html#serializers

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/dataAnalysis/baseDataAnalysis.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/dataAnalysis/baseDataAnalysis.py
@@ -46,12 +46,14 @@ class BaseDataAnalysis:
         except ValidationError as e:
             self.log.info(f"error validating '{self.istance}': {serializer.errors}")
             self.istance.error = serializer.errors
+            self.istance.save()
         except NotSerializerError as e:
             self.log.debug(f"error in data analysis '{self.istance}': {e}")
             self.istance.error = {"error": f"{e}"}
+            self.istance.save()
         except Exception as e:
             self.log.exception(f"generic error in data analysis '{self.istance}': {e}")
             self.istance.error = {"error": f"{e}"}
-        self.istance.save()
+            self.istance.save()
         self.log.info(f"finished analysis for '{self.istance}'")
         return self.istance

--- a/eddai_EliteDangerousApiInterface/eddn/tasks/auto_analytic.py
+++ b/eddai_EliteDangerousApiInterface/eddn/tasks/auto_analytic.py
@@ -16,7 +16,7 @@ class AutoAnalyticTask(Task):
     ignore_result = True
     _agent = None
     log = get_task_logger(__name__)
-    _concurrency_limit = 500
+    _concurrency_limit = 50
 
     @property
     def agent(self) -> User:


### PR DESCRIPTION
Decrease the concurrency limit for the AutoAnalyticTask and enhance error handling with automatic instance saving. Update the Celery broker heartbeat and add the --without-gossip option to worker commands for better network management.