### PR TITLE
Revert Celery worker gossip option and remove heartbeat settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,15 +38,15 @@ services:
   celery_worker_task:
     <<: *default-config
     container_name: celery_worker_task
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q default -n WorkerTasck@%h --without-gossip 
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q default -n WorkerTasck@%h 
   celery_worker_admin:
     <<: *default-config
     container_name: celery_worker_admin
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q admin -n WorkerAdmin@%h --without-gossip
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q admin -n WorkerAdmin@%h
   celery_worker_eddn:
     <<: *default-config
     container_name: celery_worker_eddn
-    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q eddn -n WorkerEddn@%h --without-gossip
+    command: celery -A eddai_EliteDangerousApiInterface worker -l info -P gevent --autoscale 200,5 -Q eddn -n WorkerEddn@%h
   celery_beat:
     <<: *default-config
     container_name: celery_beat

--- a/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
+++ b/eddai_EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/settings/default.py
@@ -336,10 +336,6 @@ EDDN_USER_PASSWORD_AGENT = os.environ.get('EDDN_USER_PASSWORD_AGENT', 'password!
 CELERY_BROKER_URL = F'amqp://{os.environ.get("CELERY_BROKER_USER")}:{os.environ.get("CELERY_BROKER_PASSWORD")}@{os.environ.get("CELERY_BROKER_HOST")}:5672/{os.environ.get("CELERY_BROKER_VHOST")}'
 CELERY_RESULT_BACKEND =  F'redis://{os.environ.get("CELERY_RESULT_BACKEND_HOST")}:{os.environ.get("CELERY_RESULT_BACKEND_PORT")}'
 
-#impostazioni per la gestione del heartbeat del broker
-#https://docs.celeryq.dev/en/v5.4.0/userguide/configuration.html#broker-heartbeat
-CELERY_BROKER_HEARTBEAT = 0
-
 #impostazioni per la gestione della serializzazione dei dati
 #https://docs.celeryq.dev/en/stable/userguide/calling.html#serializers
 CELERY_TASK_SERIALIZER = 'pickle'


### PR DESCRIPTION
Revert the addition of the `--without-gossip` option in Celery worker commands and remove the broker heartbeat settings from the configuration.