### PR TITLE
Improve serializer context handling and fix duplicate key error

### DIFF
--- a/eddai_EliteDangerousApiInterface/ed_body/api/serializers/atmosphereComponentInPlanetSerializer.py
+++ b/eddai_EliteDangerousApiInterface/ed_body/api/serializers/atmosphereComponentInPlanetSerializer.py
@@ -22,6 +22,7 @@ class ListCompactedAtmosphereComponentInPlanetSerializer(serializers.ListSeriali
             from rest_framework import status
             raise serializers.ValidationError('An internal server error occurred', code=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return attrs
+    
     def create(self, validated_data):
         atmosphereComponent = [AtmosphereComponentInPlanet(**item) for item in validated_data]
         return AtmosphereComponentInPlanet.objects.bulk_create(atmosphereComponent)

--- a/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Commodity.json
+++ b/eddai_EliteDangerousApiInterface/eddn/fixtures/eddn_test_service_event_Commodity.json
@@ -3543,5 +3543,36 @@
             },
             "error": null
         }
+    },
+    {
+        "model": "eddn.datalog",
+        "pk": 168737,
+        "fields": {
+            "created_at": "2025-02-14T23:47:59.086Z",
+            "updated_at": "2025-02-14T23:47:59.086Z",
+            "data": {
+                "header": {
+                    "gamebuild": "r308767/r0 ",
+                    "uploaderID": "923094d38a562ba31375fa8ec7d82300d8e47357",
+                    "gameversion": "4.0.0.1904",
+                    "softwareName": "E:D Market Connector [Windows]",
+                    "softwareVersion": "5.12.2",
+                    "gatewayTimestamp": "2025-02-19T10:22:41.588583Z"
+                },
+                "message": {
+                    "odyssey": true,
+                    "horizons": true,
+                    "marketId": 3707008000,
+                    "timestamp": "2025-02-19T10:22:40Z",
+                    "systemName": "Harma",
+                    "commodities": [],
+                    "stationName": "G3J-12N",
+                    "stationType": "FleetCarrier",
+                    "carrierDockingAccess": "all"
+                },
+                "$schemaRef": "https://eddn.edcd.io/schemas/commodity/3"
+            },
+            "error": null
+        }
     }
 ]

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/baseSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/baseSerializer.py
@@ -76,7 +76,7 @@ class BaseSerializer(serializers.Serializer):
                 del default_data[key]
         return default_data
 
-    def _get_data_defaults(self, validated_data:dict, function:Callable[[dict], dict]) -> dict:
+    def _get_data_defaults(self, validated_data:dict, function:Callable[[dict], dict], *args, **kwargs) -> dict:
         """
         Processes the validated data through a given function and cleans the resulting default data.
         Args:
@@ -86,10 +86,11 @@ class BaseSerializer(serializers.Serializer):
             dict: The cleaned default data.
         """
         default_data = function(validated_data)
+        default_data = {**default_data, **kwargs}
         default_data = self._clean_data_defaults(default_data)
         return default_data
     
-    def get_data_defaults(self, validated_data:dict, function:Callable[[dict], dict]=None) -> dict:
+    def get_data_defaults(self, validated_data:dict, function:Callable[[dict], dict]=None, *args, **kwargs) -> dict:
             """
             Returns the data with default values applied.
 
@@ -102,9 +103,9 @@ class BaseSerializer(serializers.Serializer):
             """
             if not function:
                 function = self.set_data_defaults
-            return self._get_data_defaults(validated_data, function)
+            return self._get_data_defaults(validated_data, function, *args, **kwargs)
 
-    def get_data_defaults_create(self, validated_data, function:Callable[[dict], dict]=None) -> dict:
+    def get_data_defaults_create(self, validated_data, function:Callable[[dict], dict]=None, *args, **kwargs) -> dict:
         """
         Returns a dictionary containing default data for creating a new object.
 
@@ -117,9 +118,9 @@ class BaseSerializer(serializers.Serializer):
         """
         if not function:
             function = self.set_data_defaults_create
-        return self._get_data_defaults(validated_data, function)
+        return self._get_data_defaults(validated_data, function, *args, **kwargs)
 
-    def get_data_defaults_update(self, validated_data, function:Callable[[dict], dict]=None) -> dict:
+    def get_data_defaults_update(self, validated_data, function:Callable[[dict], dict]=None, *args, **kwargs) -> dict:
         """
         Returns a dictionary containing default data for updating records.
 
@@ -133,7 +134,7 @@ class BaseSerializer(serializers.Serializer):
         """
         if not function:
             function = self.set_data_defaults_update
-        return self._get_data_defaults(validated_data, function)
+        return self._get_data_defaults(validated_data, function, *args, **kwargs)
 
     def get_time(self, validated_data:dict = None) -> datetime:
         """

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/commodity/commodityV3Serializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/commodity/commodityV3Serializer.py
@@ -77,7 +77,10 @@ class CommodityV3Serializer(BaseSerializer):
         }
 
     def run_update_commodities(self, instance, validated_data):
-        serializer = CommoditySerializer(data=self.initial_data.get('commodities', []), many=True)
+        serializer = CommoditySerializer(
+            data=self.initial_data.get('commodities', []), many=True,
+            context={'station': instance}
+        )
         serializer.is_valid(raise_exception=True)
         serializer.save(
             created_by=validated_data.get('created_by'),

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/dockedSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/dockedSerializer.py
@@ -79,7 +79,6 @@ class DockedSerializer(BaseJournalSerializer):
         """Set default values for the station data."""
         return {
             "landingPad": validated_data.get('LandingPads'),
-            "system": validated_data.get('system'),
             "type": validated_data.get('StationType'),
             "distance": validated_data.get('DistFromStarLS'),
             'minorFaction': MinorFaction.objects.get(name=self._get_station_minor_faction_name(validated_data)),
@@ -143,17 +142,16 @@ class DockedSerializer(BaseJournalSerializer):
         system = super().update_or_create(validated_data, update_function, create_function)
         def_create_dipendent = lambda instance: self.create_dipendent(instance, validated_data)
         def_update_dipendent = lambda instance: self.update_dipendent(instance, validated_data)
-        kwargs = {}
+        kwargs = {'name':validated_data.get('StationName')}
         if validated_data.get('StationType').eddn != 'FleetCarrier':
-            kwargs = {'system':system}
+            kwargs.update({'system':system})
         station, create = create_or_update_if_time(
             Station, time=self.get_time(),
-            defaults=self.get_data_defaults(validated_data, self.set_data_defaults_station),
+            defaults=self.get_data_defaults(validated_data, self.set_data_defaults_station, system=system),
             defaults_create=self.get_data_defaults_create(validated_data),
             defaults_update=self.get_data_defaults_update(validated_data),
             update_function=def_update_dipendent,
             create_function=def_create_dipendent,
-            name=validated_data.get('StationName'),
             **kwargs
         )
         return station

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/dockedSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/dockedSerializer.py
@@ -79,13 +79,14 @@ class DockedSerializer(BaseJournalSerializer):
         """Set default values for the station data."""
         return {
             "landingPad": validated_data.get('LandingPads'),
+            "system": validated_data.get('system'),
             "type": validated_data.get('StationType'),
             "distance": validated_data.get('DistFromStarLS'),
             'minorFaction': MinorFaction.objects.get(name=self._get_station_minor_faction_name(validated_data)),
             'primaryEconomy': self._get_primary_economy(validated_data),
             'secondaryEconomy': self._get_secondary_economy(validated_data),
         }
-    
+        
     def get_service_in_station_instace(self, station, service, validated_data):
         """Create a ServiceInStation instance with the provided data."""
         return ServiceInStation(
@@ -142,6 +143,9 @@ class DockedSerializer(BaseJournalSerializer):
         system = super().update_or_create(validated_data, update_function, create_function)
         def_create_dipendent = lambda instance: self.create_dipendent(instance, validated_data)
         def_update_dipendent = lambda instance: self.update_dipendent(instance, validated_data)
+        kwargs = {}
+        if validated_data.get('StationType').eddn != 'FleetCarrier':
+            kwargs = {'system':system}
         station, create = create_or_update_if_time(
             Station, time=self.get_time(),
             defaults=self.get_data_defaults(validated_data, self.set_data_defaults_station),
@@ -149,7 +153,7 @@ class DockedSerializer(BaseJournalSerializer):
             defaults_update=self.get_data_defaults_update(validated_data),
             update_function=def_update_dipendent,
             create_function=def_create_dipendent,
-            system=system,
             name=validated_data.get('StationName'),
+            **kwargs
         )
         return station

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/saaSignalsFoundSerializers/saaSignalsFoundSerializers.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/saaSignalsFoundSerializers/saaSignalsFoundSerializers.py
@@ -22,7 +22,8 @@ class SAASignalsFoundSerializers(SAASignalsBaseFoundSerializers):
     
     def run_update_signals(self, instance:Planet, validated_data:dict) -> None:
         serializer = SignalSerializers(
-            data=self.initial_data.get('Signals', []), many=True
+            data=self.initial_data.get('Signals', []), many=True,
+            context={'planet': instance}
         )
         serializer.is_valid(raise_exception=True)
         serializer.save(

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/saaSignalsFoundSerializers/saaSignalsHotSpotFoundSerializers.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/saaSignalsFoundSerializers/saaSignalsHotSpotFoundSerializers.py
@@ -24,7 +24,8 @@ class SAASignalsHotSpotFoundSerializers(SAASignalsBaseFoundSerializers):
 
     def run_update_hotspot(self, instance:Ring, validated_data:dict) -> None:
         serializer = HotspotSerializers(
-            data=self.initial_data.get('Signals', []), many=True
+            data=self.initial_data.get('Signals', []), many=True,
+            context={'ring': instance}
         )
         serializer.is_valid(raise_exception=True)
         serializer.save(

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/scan/planetScanSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/journal/scan/planetScanSerializer.py
@@ -105,7 +105,10 @@ class PlanetScanSerializer(BaseScanSerializer):
     
     def run_update_materials(self, instance, validated_data):
         if validated_data.get('Materials', None):
-            serializer = MaterialsSerializer(data=self.initial_data.get('Materials', []), many=True)
+            serializer = MaterialsSerializer(
+                data=self.initial_data.get('Materials', []), many=True,
+                context={'planet': instance}
+            )
             serializer.is_valid(raise_exception=True)
             serializer.save(
                 created_by=validated_data.get('created_by'),
@@ -116,7 +119,10 @@ class PlanetScanSerializer(BaseScanSerializer):
 
     def run_update_atmosphereComposition(self, instance, validated_data):
         if validated_data.get('AtmosphereComposition', None):
-            serializer = AtmosphereComponentSerializer(data=self.initial_data.get('AtmosphereComposition', []), many=True)
+            serializer = AtmosphereComponentSerializer(
+                data=self.initial_data.get('AtmosphereComposition', []), many=True,
+                context={'planet': instance}
+            )
             serializer.is_valid(raise_exception=True)
             serializer.save(
                 created_by=validated_data.get('created_by'),

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/atmosphereComponentSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/atmosphereComponentSerializer.py
@@ -9,14 +9,13 @@ from ed_body.models import AtmosphereComponentInPlanet, AtmosphereComponent
 
 class AtmosphereComponentListSerializer(serializers.ListSerializer):
 
-    def _get_plante(self, validated_data):
-        return validated_data[0].get('planet')
+    def _get_plante(self):
+        return self.context.get('planet')
 
     def create(self, validated_data):
-        plante = self._get_plante(validated_data)
         atmosphere_component_in_planet_add = []
         atmosphere_component_in_planet_delete = []
-        atmosphere_component_in_planet__qs_list = list(AtmosphereComponentInPlanet.objects.filter(planet=plante))
+        atmosphere_component_in_planet__qs_list = list(AtmosphereComponentInPlanet.objects.filter(planet=self._get_plante()))
         atmosphere_component_in_planet = [AtmosphereComponentInPlanet(**item) for item in validated_data]
         for atmosphereComponent in atmosphere_component_in_planet:
             if not in_list_models(atmosphereComponent, atmosphere_component_in_planet__qs_list):

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/commoditySerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/commoditySerializer.py
@@ -9,8 +9,8 @@ from core.utility import in_list_models
 
 class CommodityListSerializer(serializers.ListSerializer):
 
-    def _get_station(self, validated_data):
-        return validated_data[0].get('station')
+    def _get_station(self):
+        return self.context.get('station')
     
     def get_commodity_mean_prices(self, validated_data):
         commodity_mean_prices = []
@@ -41,7 +41,7 @@ class CommodityListSerializer(serializers.ListSerializer):
         self.update_commodity_mean_prices(commodity_mean_prices)
         commodity_in_station_add = []
         commodity_in_station_delete = []
-        commodity_in_station_qs = list(CommodityInStation.objects.filter(station=self._get_station(validated_data)))
+        commodity_in_station_qs = list(CommodityInStation.objects.filter(station=self._get_station()))
         commodity_in_station_list = [CommodityInStation(**item) for item in validated_data]
         for commodity_in_station in commodity_in_station_list:
             if not in_list_models(commodity_in_station, commodity_in_station_qs):

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/hotspotSerializers.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/hotspotSerializers.py
@@ -14,14 +14,13 @@ class HotspotListSerializer(serializers.ListSerializer):
             raise serializers.ValidationError(f"too few hotspots: {count}")
         return super().validate(attrs)
     
-    def _get_ring(self, validated_data):
-        return validated_data[0].get('ring')
+    def _get_ring(self):
+        return self.context.get('ring')
     
     def create(self, validated_data):
-        ring = self._get_ring(validated_data)
         hotspot_add = []
         hotspot_delete = []
-        hotspot_qs = list(HotSpot.objects.filter(ring=ring))
+        hotspot_qs = list(HotSpot.objects.filter(ring=self._get_ring()))
         hotspot_list = [HotSpot(**item) for item in validated_data]
         for hotspot in hotspot_list:
             if not in_list_models(hotspot, hotspot_qs):

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/materialsSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/materialsSerializer.py
@@ -9,14 +9,13 @@ from ed_material.models import Material, MaterialInPlanet
 
 class MaterialsSerializerListSerializer(serializers.ListSerializer):
 
-    def _get_plante(self, validated_data):
-        return validated_data[0].get('planet')
+    def _get_plante(self):
+        return self.context.get('planet')
 
     def create(self, validated_data):
-        plante = self._get_plante(validated_data)
         materials_in_planet_add = []
         materials_in_planet_delete = []
-        materials_in_planet_qs_list = list(MaterialInPlanet.objects.filter(planet=plante))
+        materials_in_planet_qs_list = list(MaterialInPlanet.objects.filter(planet=self._get_plante()))
         materials = [MaterialInPlanet(**item) for item in validated_data]
         for material in materials:
             if not in_list_models(material, materials_in_planet_qs_list):

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/signalSerializers.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/signalSerializers.py
@@ -13,11 +13,11 @@ class SignalListSerializer(serializers.ListSerializer):
             raise serializers.ValidationError(f"too few hotspots: {count}")
         return super().validate(attrs)
     
-    def _get_planet(self, validated_data):
-        return validated_data[0].get('planet')
+    def _get_planet(self):
+        return self.context.get('planet')
     
     def create(self, validated_data):
-        planet = self._get_planet(validated_data)
+        planet = self._get_planet()
         signal_add = []
         signal_delete = []
         signal_qs = list(Signal.objects.filter(planet=planet))


### PR DESCRIPTION
Add context to serializers to prevent errors with empty data and manage variable arguments. Fix the 'duplicate key' error for FleetCarrier.