### PR TITLE
Remove Celery worker dependency from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,8 +84,6 @@ services:
     <<: *default-config
     container_name: eddn
     command: python eddn.py
-    depends_on:
-      - celery_worker_eddn
   nginx:
     build: ./nginx
     container_name: nginx


### PR DESCRIPTION
Eliminate the dependency on the Celery worker in the docker-compose configuration to streamline service management.