### PR TITLE
Update Django service timeout and JSON data models

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,4 +45,4 @@ EDDN_USER_PASSWORD_AGENT = "password"
 ################################################################################
 ### VISUAL STUDIO CODE
 ################################################################################
-MANAGE_PY_PATH=eddai_EliteDangerousApiInterface/manage.py
+MANAGE_PY_PATH=/workspaces/EDDAI-EliteDangerousApiInterface/eddai_EliteDangerousApiInterface/manage.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
-    "python.testing.unittestArgs": [
-        "-p",
-        "*test*.py"
-    ],
+    "python.testing.unittestArgs": [],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "python.experiments.optInto": ["pythonTestAdapter"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   django:
     <<: *default-config
     container_name: django
-    command: python -m gunicorn eddai_EliteDangerousApiInterface.wsgi:application -b :8080 --timeout 120
+    command: python -m gunicorn eddai_EliteDangerousApiInterface.wsgi:application -b :8080 --timeout 60
     volumes:
       - static_volume:/app/static-server
       - media_volume:/app/media-server

--- a/eddai_EliteDangerousApiInterface/ed_bgs/fixtures/bgs.json
+++ b/eddai_EliteDangerousApiInterface/ed_bgs/fixtures/bgs.json
@@ -495,11 +495,21 @@
   },
   {
     "model": "ed_bgs.power",
-    "pk": 4,
+    "pk": 1,
     "fields": {
-      "name": "Aisling Duval",
-      "headquarter": 4,
+      "name": "Zemina Torval",
+      "headquarter": 1,
       "allegiance": 6,
+      "note": ""
+    }
+  },
+  {
+    "model": "ed_bgs.power",
+    "pk": 2,
+    "fields": {
+      "name": "Felicia Winters",
+      "headquarter": 2,
+      "allegiance": 7,
       "note": ""
     }
   },
@@ -509,6 +519,16 @@
     "fields": {
       "name": "A. Lavigny-Duval",
       "headquarter": 3,
+      "allegiance": 6,
+      "note": ""
+    }
+  },
+  {
+    "model": "ed_bgs.power",
+    "pk": 4,
+    "fields": {
+      "name": "Aisling Duval",
+      "headquarter": 4,
       "allegiance": 6,
       "note": ""
     }
@@ -545,26 +565,6 @@
   },
   {
     "model": "ed_bgs.power",
-    "pk": 2,
-    "fields": {
-      "name": "Felicia Winters",
-      "headquarter": 2,
-      "allegiance": 7,
-      "note": ""
-    }
-  },
-  {
-    "model": "ed_bgs.power",
-    "pk": 11,
-    "fields": {
-      "name": "Jerome Archer",
-      "headquarter": 9,
-      "allegiance": 7,
-      "note": ""
-    }
-  },
-  {
-    "model": "ed_bgs.power",
     "pk": 8,
     "fields": {
       "name": "Li Yong-Rui",
@@ -575,10 +575,10 @@
   },
   {
     "model": "ed_bgs.power",
-    "pk": 12,
+    "pk": 9,
     "fields": {
-      "name": "Pranav Antal",
-      "headquarter": 12,
+      "name": "Nakato Kaine",
+      "headquarter": 3304,
       "allegiance": 1,
       "note": ""
     }
@@ -595,11 +595,21 @@
   },
   {
     "model": "ed_bgs.power",
-    "pk": 1,
+    "pk": 11,
     "fields": {
-      "name": "Zemina Torval",
-      "headquarter": 1,
-      "allegiance": 6,
+      "name": "Jerome Archer",
+      "headquarter": 9,
+      "allegiance": 7,
+      "note": ""
+    }
+  },
+  {
+    "model": "ed_bgs.power",
+    "pk": 12,
+    "fields": {
+      "name": "Pranav Antal",
+      "headquarter": 12,
+      "allegiance": 1,
       "note": ""
     }
   },

--- a/eddai_EliteDangerousApiInterface/ed_economy/fixtures/economy.json
+++ b/eddai_EliteDangerousApiInterface/ed_economy/fixtures/economy.json
@@ -4244,6 +4244,16 @@
         }
     },
     {
+        "model": "ed_economy.commodity",
+        "pk": 387,
+        "fields": {
+            "_eddn": "USSCargoExperimentalChemicals",
+            "name": "Experimental Chemicals",
+            "description": "",
+            "meanPrice": 0
+        }
+    },
+    {
         "model": "ed_economy.economy",
         "pk": 1,
         "fields": {

--- a/eddai_EliteDangerousApiInterface/ed_system/fixtures/system.json
+++ b/eddai_EliteDangerousApiInterface/ed_system/fixtures/system.json
@@ -245,6 +245,25 @@
         "conrollingFaction": null,
         "description": ""
       }
+    },
+    {
+      "model": "ed_system.system",
+      "pk": 3304,
+      "fields": {
+        "created_at": "2025-03-02T16:38:44.347767Z",
+        "updated_at": "2025-03-03T09:22:59.188804Z",
+        "created_by": 1,
+        "updated_by": 1,
+        "name": "Tionisla",
+        "address": 5031789105890,
+        "coordinate":"SRID=4979;POINT Z (82.25 48.75 68.15625)",
+        "security": "H",
+        "population": 5200016905,
+        "primaryEconomy": 3,
+        "secondaryEconomy": 4,
+        "conrollingFaction": null,
+        "description": ""
+      }
     }
   ]
   


### PR DESCRIPTION
Reduce the Django service timeout to 60 seconds, update faction and system data in JSON files, and add a new commodity model for 'Experimental Chemicals'. Additionally, adjust the manage.py path in the configuration.