### PR TITLE
Update economic and power state values for flexibility and new entity

### DIFF
--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Build the Docker image
         run: docker build --file eddai_EliteDangerousApiInterface/Dockerfile -t eddaielitedangerousapiinterface:latest "eddai_EliteDangerousApiInterface" 
       - name: Run database flush
-        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py flush --no-input
+        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGRES_DB=ed_info -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py flush --no-input
       - name: Run database migrations
-        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py migrate
+        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGRES_DB=ed_info -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py migrate
       - name: Run tests
-        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py test
+        run: docker run --rm --network host -e DJANGO_SECRET_KEY='5^_hu^y$-f!okdysc6wrp)x^s6vzd=!d68#vm7+*(mkhwt@b11' -e DJANGO_SETTINGS_MODULE=eddai_EliteDangerousApiInterface.settings.test -e POSTGRES_DB=ed_info -e POSTGIS_USER=test_user -e POSTGIS_PASSWORD=test_password -e POSTGIS_HOST=localhost -e POSTGIS_PORT=5432 eddaielitedangerousapiinterface:latest python manage.py test
       - name: Set pull request status to failure
         if: failure()
         run: |

--- a/eddai_EliteDangerousApiInterface/ed_bgs/fixtures/bgs.json
+++ b/eddai_EliteDangerousApiInterface/ed_bgs/fixtures/bgs.json
@@ -615,9 +615,9 @@
   },
   {
     "model": "ed_bgs.powerstate",
-    "pk": 4,
+    "pk": 10,
     "fields": {
-      "_eddn": null,
+      "_eddn": "Unoccupied",
       "name": "Contested",
       "description": ""
     }

--- a/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
+++ b/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
@@ -34,7 +34,7 @@ class PowerInSystem(OwnerAndDateModels):
         """
         Returns the maximum relation value.
         """
-        return 4
+        return 6
 
     @staticmethod
     def StateForMoreRellation() -> PowerState:

--- a/eddai_EliteDangerousApiInterface/ed_economy/fixtures/economy.json
+++ b/eddai_EliteDangerousApiInterface/ed_economy/fixtures/economy.json
@@ -4412,5 +4412,15 @@
             "name": "None",
             "description": ""
         }
+    },
+    {
+        "model": "ed_economy.economy",
+        "pk": 18,
+        "fields": {
+            "_eddn": "$economy_Prison;",
+            "eddn": "$economy_Prison;",
+            "name": "Prison",
+            "description": ""
+        }
     }
 ]

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/economySerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/economySerializer.py
@@ -9,5 +9,5 @@ class EconomySerializer(serializers.Serializer):
     )
     Proportion = serializers.FloatField(
         min_value=0,
-        max_value=1,
+        max_value=1.15,
     )


### PR DESCRIPTION
This pull request includes various changes to improve the configuration, data fixtures, and serializers in the project. The most important changes include updating the GitHub workflow to include the `POSTGRES_DB` environment variable, modifying fixture data for `powerstate` and `economy`, adjusting the maximum relation value in the `PowerInSystem` model, and updating the `EconomySerializer` to allow a higher maximum value for the `Proportion` field.

### Configuration updates:
* [`.github/workflows/check-and-test.yml`](diffhunk://#diff-ad66ae649af963716c82c6420cd551be7f1d800d8a681e90df42ab79ba0a3cf6L33-R37): Added the `POSTGRES_DB` environment variable to the database flush, migration, and test steps.

### Data fixture updates:
* [`eddai_EliteDangerousApiInterface/ed_bgs/fixtures/bgs.json`](diffhunk://#diff-bc8a42401bf092dcc60bd39b98cd270b12a435479e57559168d40fb143f67c1fL618-R620): Changed the primary key and `_eddn` field for the `powerstate` model.
* [`eddai_EliteDangerousApiInterface/ed_economy/fixtures/economy.json`](diffhunk://#diff-92bf8bf86b6772d682383783a128e4a6a93e25bd59dbf11af4682639538d171fR4415-R4424): Added a new economy type with the primary key `18` and `_eddn` value `$economy_Prison;`.

### Model updates:
* [`eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py`](diffhunk://#diff-e8644ec977ef56fe7ed75d0b3605a37355c33f2d82401d2c6901acb49bc679b9L37-R37): Updated the `get_max_relations` method to return `6` instead of `4`.

### Serializer updates:
* [`eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/economySerializer.py`](diffhunk://#diff-a0fe6ad94b1a032f48ba6a4a6db32c228c9fb4023a9edb2c34f0856c8ba71e6bL12-R12): Increased the `max_value` for the `Proportion` field from `1` to `1.15`.