### PR TITLE
Update maximum relation and proportion values

### DIFF
--- a/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
+++ b/eddai_EliteDangerousApiInterface/ed_bgs/models/PowerInSystem.py
@@ -34,7 +34,7 @@ class PowerInSystem(OwnerAndDateModels):
         """
         Returns the maximum relation value.
         """
-        return 6
+        return 12
 
     @staticmethod
     def StateForMoreRellation() -> PowerState:

--- a/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/economyLowerSerializer.py
+++ b/eddai_EliteDangerousApiInterface/eddn/service/worker/serializers/nestedSerializers/economyLowerSerializer.py
@@ -8,5 +8,5 @@ class EconomyLowerSerializer(serializers.Serializer):
     )
     proportion = serializers.FloatField(
         min_value=0,
-        max_value=1,
+        max_value=2,
     )


### PR DESCRIPTION
Increase the maximum relation value in PowerInSystem to 12 and adjust the maximum proportion value in EconomyLowerSerializer to 2.