### PR TITLE
Add ServiceViewSet for CRUD operations on Service model

### DIFF
--- a/eddai_EliteDangerousApiInterface/ed_station/api/serializers/__init__.py
+++ b/eddai_EliteDangerousApiInterface/ed_station/api/serializers/__init__.py
@@ -1,3 +1,4 @@
 from .StationSerializer import StationSerializer, StationDistanceSerializer, StationBasicInformation
 from .stationTypeBasicInformationSerializer import StationTypeBasicInformationSerializer
 from .serviceInStationSerializer import ServiceInStationSerializer
+from .serviceSerializer import CompactedServiceSerializer, ServiceSerializer

--- a/eddai_EliteDangerousApiInterface/ed_station/api/serializers/serviceSerializer.py
+++ b/eddai_EliteDangerousApiInterface/ed_station/api/serializers/serviceSerializer.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from ed_station.models import Service
+
+class CompactedServiceSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Service
+        fields = ['id', 'name']
+
+class ServiceSerializer(CompactedServiceSerializer):
+
+    class Meta(CompactedServiceSerializer.Meta):
+        fields = None
+        exclude = ['_eddn']

--- a/eddai_EliteDangerousApiInterface/ed_station/api/urls.py
+++ b/eddai_EliteDangerousApiInterface/ed_station/api/urls.py
@@ -17,10 +17,11 @@ Including another URLconf
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from .venws import StationViewSet, ServiceInStationViewSet
+from .venws import StationViewSet, ServiceInStationViewSet, ServiceViewSet
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'stations', StationViewSet)
+router.register(r'services', ServiceViewSet)
 router.register(r'stations/(?P<station_pk>[^/.]+)/services', ServiceInStationViewSet)
 
 urlpatterns = router.urls

--- a/eddai_EliteDangerousApiInterface/ed_station/api/venws/__init__.py
+++ b/eddai_EliteDangerousApiInterface/ed_station/api/venws/__init__.py
@@ -1,2 +1,3 @@
 from .stationViewSet import StationViewSet
 from .serviceInStationViewSet import ServiceInStationViewSet
+from .serviceViewSet import ServiceViewSet

--- a/eddai_EliteDangerousApiInterface/ed_station/api/venws/serviceViewSet.py
+++ b/eddai_EliteDangerousApiInterface/ed_station/api/venws/serviceViewSet.py
@@ -1,0 +1,24 @@
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from rest_framework.filters import SearchFilter
+
+from ..serializers import CompactedServiceSerializer, ServiceSerializer
+from ed_station.models import Service
+
+class ServiceViewSet(ReadOnlyModelViewSet):
+    """
+    ServiceViewSet is a viewset for handling CRUD operations on the Service model.
+    Attributes:
+        queryset (QuerySet): A queryset of all Service objects.
+        serializer_class (type): The serializer class used for serializing and deserializing the model.
+    """
+    
+    queryset = Service.objects.all()
+    serializer_class = ServiceSerializer
+    filter_backends = [SearchFilter]
+    search_fields = ['name']
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return CompactedServiceSerializer
+        return super().get_serializer_class()


### PR DESCRIPTION
Introduce ServiceViewSet to manage CRUD operations for the Service model, including filtering by name. Update serializers and routing accordingly.